### PR TITLE
Updated samples to use Rsk.AdminUI.6.8.0

### DIFF
--- a/Base Installation/Base Installation.csproj
+++ b/Base Installation/Base Installation.csproj
@@ -77,7 +77,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
 

--- a/CustomDatabaseConnection/CustomDatabaseConnection.csproj
+++ b/CustomDatabaseConnection/CustomDatabaseConnection.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+    <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
   </ItemGroup>
 
 </Project>

--- a/EF Tenancy/EF Tenancy.csproj
+++ b/EF Tenancy/EF Tenancy.csproj
@@ -9,14 +9,14 @@
 
     <ItemGroup>
       <PackageReference Include="EntityFramework" Version="6.4.4" />
-      <PackageReference Include="IdentityExpress.Identity" Version="6.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.8">
+      <PackageReference Include="IdentityExpress.Identity" Version="6.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.16" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.16">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
 

--- a/Extending/Extending.csproj
+++ b/Extending/Extending.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
 

--- a/Full Implementation Starting Point/Full Implementation Starting Point.csproj
+++ b/Full Implementation Starting Point/Full Implementation Starting Point.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
   

--- a/NoSQL Starting Point/NoSQL Starting Point.csproj
+++ b/NoSQL Starting Point/NoSQL Starting Point.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
 

--- a/Overriding/Overriding.csproj
+++ b/Overriding/Overriding.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rsk.AdminUI" Version="6.7.2" />
+      <PackageReference Include="Rsk.AdminUI" Version="6.8.0-alpha.59885" />
       <PackageReference Include="Rsk.CustomIdentity" Version="2.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Rsk.AdminUI.6.8.0 adopts a new model for defining settings that are independent of traditional configuration sources (e.g. appsettings.json). However, as settings can still be read from configuration it is backwards compatible with older versions.